### PR TITLE
Describe fixed JSX highlighting in nvim-ts-rainbow

### DIFF
--- a/contents/2022/Aug/15.md
+++ b/contents/2022/Aug/15.md
@@ -28,6 +28,21 @@ People have been busy but… nothing really interesting worth discussing for thi
 
 ## [Updates](#updates) {#updates}
 
+### nvim-ts-rainbow
+
+![A screenshot of some JSX code with `nvim-ts-rainbow` enabled. JSX tag names
+are highlighted but their props are left
+intact.](https://user-images.githubusercontent.com/889383/183246789-1f322e79-aca2-499b-979e-2ff81feeefc6.png)
+
+`nvim-ts-rainbow` gained improved support for highlighting JSX elements in JSX
+and TSX files in `extended_mode`.
+Only the tag names and angle brackets are highlighted. Props retain their usual
+highlighting, which makes them easier to read.
+
+- [Reddit](https://www.reddit.com/r/neovim/comments/wj35b4/nvimtsrainbow_improved_highlighting_of_jsx/)
+- [GitHub](https://github.com/p00f/nvim-ts-rainbow)
+- [PR](https://github.com/p00f/nvim-ts-rainbow/pull/125)
+
 ---
 
 # [Did you know?](#tips) {#tips}

--- a/contents/2022/Aug/15.md
+++ b/contents/2022/Aug/15.md
@@ -28,7 +28,16 @@ People have been busy but… nothing really interesting worth discussing for thi
 
 ## [Updates](#updates) {#updates}
 
-### nvim-ts-rainbow
+<h3 id="update-nvim-ts-rainbow">
+  <a href="#update-nvim-ts-rainbow">
+    <span class="icon-text">
+      <span class="icon">
+        <i class="fa-solid fa-book"></i>
+      </span>
+      <span>nvim-ts-rainbow</span>
+    </span>
+  </a>
+</h3>
 
 ![A screenshot of some JSX code with `nvim-ts-rainbow` enabled. JSX tag names
 are highlighted but their props are left


### PR DESCRIPTION
I wanted to mention my latest contribution to [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow) that fixes JSX props highlighting - [an issue](https://github.com/p00f/nvim-ts-rainbow/issues/118) that annoyed me for quite some time.