### PR TITLE
fixes incorrect style caused by previous pr of zhiyuan.nvim

### DIFF
--- a/contents/2022/Oct/17.md
+++ b/contents/2022/Oct/17.md
@@ -30,24 +30,6 @@ Copilot Panel, with custom keybindings and configurable settings. It also integr
 
 - [GitHub](https://github.com/zbirenbaum/copilot.lua)
 
-
-## [New plugins](#new-plugins) {#new-plugins}
-
-<h3 id="zhiyuan.nvim">
-  <a href="#new-copilot.lua">
-    <span class="icon-text">
-      <span class="icon">
-        <i class="fa-solid fa-robot"></i>
-      </span>
-      <span>zhiyuan.nvim</span>
-    </span>
-  </a>
-</h3>
-
-zhiyuan.nvim provides a way to send system-wide notifications on linux using libnotify and lua ffi.
-
-- [GitHub](https://github.com/haolian9/zhiyuan.nvim)
-
 ---
 
 <h3 id="new-mini.map">
@@ -301,6 +283,23 @@ Toggle various text (booleans, dates, etc.) with simple shortcuts.
 
 - [Reddit](https://www.reddit.com/r/neovim/comments/y2h9sq/new_plugin_boolenvim_toggle_booleans_cycle_days/)
 - [GitHub](https://github.com/nat-418/boole.nvim)
+
+---
+
+<h3 id="zhiyuan.nvim">
+  <a href="#zhiyuan.lua">
+    <span class="icon-text">
+      <span class="icon">
+        <i class="fa-thin fa-kite"></i>
+      </span>
+      <span>zhiyuan.nvim</span>
+    </span>
+  </a>
+</h3>
+
+zhiyuan.nvim provides a way to send system-wide notifications on linux using libnotify and lua ffi. By [@haoliang](https://github.com/haolian9).
+
+- [GitHub](https://github.com/haolian9/zhiyuan.nvim)
 
 ---
 


### PR DESCRIPTION
hi, @phaazon. in my previous pr #51, i made a mistake that uses another `## [New plugins](#new-plugins) {#new-plugins}`, i also moved zhiyuan.nvim to the end of "New Plugins" section.

is it possible to have this fixed before publishing? since the oct-17 has not been published, this mistake also could break TWiN's releasing procedure, maybe.