### PR TITLE
Fix typo in boole.nvim

### DIFF
--- a/contents/2022/Oct/17.md
+++ b/contents/2022/Oct/17.md
@@ -295,7 +295,7 @@ A “toy and exercise” plugin in floating buffers to enhance your knowledge an
     </a>
 </h3>
 
-![boole.nvim]((https://user-images.githubusercontent.com/506592/196062261-ffd57a5a-26a9-4998-9307-faf1d4d6deed.png)
+![boole.nvim](https://user-images.githubusercontent.com/506592/196062261-ffd57a5a-26a9-4998-9307-faf1d4d6deed.png)
 
 Toggle various text (booleans, dates, etc.) with simple shortcuts.
 


### PR DESCRIPTION
remove unnecessary `(`.