### PR TITLE
adds normalascii.nvim

### DIFF
--- a/contents/2022/Oct/30.md
+++ b/contents/2022/Oct/30.md
@@ -242,6 +242,23 @@ A really nice addition!
 
 ---
 
+<h3 id="new-normalascii.nvim">
+    <a href="#new-normalascii.nvim">
+        <span class="icon-text">
+            <span class="icon">
+                <i class="fa-solid fa-book"></i>
+            </span>
+            <span>normalascii.nvim</span>
+        </span>
+    </a>
+</h3>
+
+It provides several Nvim lua APIs to turn on the `ascii mode` of Rime based on Fcitx5's DBUS API. By [@haolian9](https://github.com/haolian9).
+
+- [GitHub](https://github.com/haolian9/normalascii.nvim)
+
+---
+
 ## [Updates](#updates) {#updates}
 
 <h3 id="update-NeoSolarized.nvim">


### PR DESCRIPTION
Hi, i made a Nvim plugin to help user to turn on the `ascii mode` of Rime IME.
Could you consider adding it to the TWiN?