### PR TITLE
adds redostr.nvim

### DIFF
--- a/contents/2022/Nov/21/3-new-plugins/9-redostr.nvim.md
+++ b/contents/2022/Nov/21/3-new-plugins/9-redostr.nvim.md
@@ -1,0 +1,20 @@
+<h3 id="redostr.nvim">
+  <a href="#redostr.nvim">
+    <span class="icon-text">
+      <span class="icon">
+        <i class="fa-solid fa-book"></i>
+      </span>
+      </span>
+      <span>redostr.nvim</span>
+    </a>
+  </h3>
+</h3>
+
+It provides one API to return the redo string used by `.`.
+
+Created by haolian9.
+
+- [GitHub](https://github.com/haolian9/redostr.nvim)
+
+---
+


### PR DESCRIPTION
Hi, I made a simple plugin that reveals the redo string used by `.`. can it be added to the TWiN?