### PR TITLE
Fix username references in 2023-01-09

### DIFF
--- a/contents/2023/Jan/09/3-new-plugins/2-incolla.nvim.md
+++ b/contents/2023/Jan/09/3-new-plugins/2-incolla.nvim.md
@@ -12,7 +12,7 @@
 ![incolla.nvim](https://user-images.githubusercontent.com/22748355/210150002-135316ea-5574-443c-b71b-cc089784df7e.gif)
 
 A Neovim Lua plugin to paste images from the MacOS clipboard. No dependencies, works for multiple formats and sources.
-Written by [@mattdibi](https://github.com/mattdibi/incolla.nvim).
+Written by [@mattdibi](https://github.com/mattdibi).
 
 - [GitHub](https://github.com/mattdibi/incolla.nvim)
 

--- a/contents/2023/Jan/09/3-new-plugins/4-telescope-all-recent.nvim.md
+++ b/contents/2023/Jan/09/3-new-plugins/4-telescope-all-recent.nvim.md
@@ -12,6 +12,6 @@
 ![telescope-all-recent.nvim](https://user-images.githubusercontent.com/38609485/210369490-98c0fecc-ad96-4efa-9360-55b012d70eb6.gif)
 
 A [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) modification for adding (f)recency sorting to any
-telescope picker. Written by [@prochri](https://github.com/prochri/telescope-all-recent.nvim).
+telescope picker. Written by [@prochri](https://github.com/prochri).
 
 - [GitHub](https://github.com/prochri/telescope-all-recent.nvim)

--- a/contents/2023/Jan/09/3-new-plugins/5-ts-node-action.md
+++ b/contents/2023/Jan/09/3-new-plugins/5-ts-node-action.md
@@ -22,7 +22,7 @@ Some of the built-in functions are:
 - Toggle conditionals without else into postfix format and back
 - ... And more! Check out github for the full list :)
 
-Pull requests for language support are welcome! Written by [@CKolkey](https://github.com/CKolkey/ts-node-action)!
+Pull requests for language support are welcome! Written by [@CKolkey](https://github.com/CKolkey)!
 
 - [Reddit](https://old.reddit.com/r/neovim/comments/1054s17/new_plugin_preview_treesitter_node_action/)
 - [GitHub](https://github.com/CKolkey/ts-node-action)

--- a/contents/2023/Jan/09/3-new-plugins/6-bufferline-cycle-windowless.md
+++ b/contents/2023/Jan/09/3-new-plugins/6-bufferline-cycle-windowless.md
@@ -16,7 +16,7 @@ Neovims default tab-window-buffer model allows viewing open buffers in multiple 
 This plugin helps give a more traditional behaviour for tabs by configuring the ability to skip past buffers that are
 already open in an existing window. The behaviour is toggleable and configurable to be on or off by default.
 
-Written by [@roobert](https://github.com/roobert/bufferline-cycle-windowless.nvim).
+Written by [@roobert](https://github.com/roobert).
 
 - [Github](https://github.com/roobert/bufferline-cycle-windowless.nvim)
 


### PR DESCRIPTION
Mentions like `@foo` should point to `https://github.com/foo`
In 2023-01-09 issue, there're some references that look different.
This commit fixes all of them to point GitHub user page.