### PR TITLE
fix a small typo

### DIFF
--- a/contents/2023/Jan/23/3-new-plugins/8-yop.nvim.md
+++ b/contents/2023/Jan/23/3-new-plugins/8-yop.nvim.md
@@ -9,7 +9,7 @@
   </a>
 </h3>
 
-A new plugin that makes aims to make it as easy as possible to make your own custom Neovim operators (like `d`, `c`, 
+A new plugin that aims to make it as easy as possible to make your own custom Neovim operators (like `d`, `c`, 
 `gq`, and `y`). Just define a handler function and put it in a keymap!
 
 Checkout some [examples](https://github.com/zdcthomas/yop.nvim/wiki/Example-mappings)!


### PR DESCRIPTION
Noticed a misplaced word in the 2023 Jan 23 newsletter. This is just a minuscule PR to correct that :)

Should this be merged to master and then Jan-30 rebased or merged straight to Jan-30 branch?