### PR TITLE
fix: flatten.nvim and relative-toggle videos (2023-Mar14)

### DIFF
--- a/contents/2023/Mar/14/3-new-plugins/01-flatten.nvim.md
+++ b/contents/2023/Mar/14/3-new-plugins/01-flatten.nvim.md
@@ -9,7 +9,11 @@
   </a>
 </h3>
 
-![flatten.nvim](https://user-images.githubusercontent.com/38540736/224443095-91450818-f298-4e08-a951-ee3fcc607330.mp4)
+<video controls>
+  <source
+    src="https://user-images.githubusercontent.com/38540736/224443095-91450818-f298-4e08-a951-ee3fcc607330.mp4"
+  >
+</video>
 
 Flatten.nvim allows you to open files from a Neovim terminal buffer in your current Neovim session. It's easily 
 configurable, and supports blocking so programs which need a pager / editor can use the current Neovim session as well. 

--- a/contents/2023/Mar/14/3-new-plugins/03-relative-toggle.nvim.md
+++ b/contents/2023/Mar/14/3-new-plugins/03-relative-toggle.nvim.md
@@ -9,7 +9,11 @@
   </a>
 </h3>
 
-![relative-toggle.nvim](https://user-images.githubusercontent.com/42694704/224506660-75dc1e01-83ef-4cab-9361-55b45a1c4539.mov)
+<video controls>
+  <source
+    src="https://user-images.githubusercontent.com/42694704/224506660-75dc1e01-83ef-4cab-9361-55b45a1c4539.mov"
+  >
+</video>
 
 This plugin will enhance your Neovim experience by automatically toggling smoothly between relative and absolute line 
 numbers in various Neovim events. This is useful when you want to take advantage of the information on those types of 


### PR DESCRIPTION
Sorry about that @phaazon! Wasn't aware embedding vids in markdown didn't work properly.

EDIT: It appears `relative-toggle` has had the same issue. 